### PR TITLE
make webpack5 compatible, fix the tags and resolve the import warning

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'ejs-webpack-plugin';

--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ function makeTags(file, assets, type) {
         if (i.substr(-4) !== '.map' && i.indexOf(file) !== -1) {
             console.log(file, type, path.normalize(i), new RegExp(file).test(path.normalize(i)))
             if (type === 'js' && /\.js/.test(path.normalize(i))) {
-                tags += '<script type="text/javascript" src = ' + path.normalize(i) + '></script>';
+                tags += '<script type="text/javascript" src="/' + path.posix.normalize(i) + '" defer></script>';
 
-            } else if (type === 'css' && new RegExp(file).test(path.normalize(i))) {
-                tags += '<link rel="stylesheet" href=' + path.normalize(i) + ' />'
+            } else if (type === 'css' && /\.css/.test(path.normalize(i))) {
+                tags += '<link rel="stylesheet" href="/' + path.posix.normalize(i) + '" />'
             }
         }
     })
@@ -50,7 +50,7 @@ function regReplace(origin, replaceContent, ref, type) {
 }
 
 EjsWebpackPlugin.prototype.ejsInject = function (assets , assets2 , assetTag , self) {
- 
+
     var entry = this.options.entry;
     var ejsList = Object.keys(entry);
 
@@ -326,13 +326,12 @@ EjsWebpackPlugin.prototype.createHtmlTag = function (tagDefinition) {
 EjsWebpackPlugin.prototype.apply = function (compiler) {
     var _this = this
 
-    compiler.plugin('emit', function (compilation, callback) {
-
+    compiler.hooks.emit.tapAsync('EjsWebpackPlugin', function (compilation, callback) {
         var allChunks = compilation.getStats().toJson().chunks;
         var chunks = _this.filterChunks(allChunks, _this.options.chunks, _this.options.excludeChunks);
         var assets = _this.htmlWebpackPluginAssets(compilation, chunks);
         var assetTags = _this.generateAssetTags(assets);
-         
+        
 
         _this.ejsInject(Object.keys(compilation.assets) , assets , { body: assetTags.body, head: assetTags.head }, _this)
         callback()


### PR DESCRIPTION
## What
- I've modified the "EjsWebpackPlugin.prototype.apply" function to make it compatible with webpack5. 
- I also fixed the tags in the "makeTags" function. 
- I finally added an "index.d.ts" file to fix the import warning.

## Why
- The "compiler.plugin" method no longer works in webpack5. 
- There aren't any double quotes and there are backward slashes (\) instead of forward slashes (/) in the tags. Also, it was adding the "js" files in the link stylesheet tag.
- When importing the plugin (`import ejsPlugin from 'ejs-webpack-plugin'`) it gives a warning "Could not find a declaration file for module 'ejs-webpack-plugin'".

## How
- I replaced the ` compiler.plugin('emit', function (compilation, callback) { ... }` method with `compiler.hooks.emit.tapAsync('EjsWebpackPlugin', function (compilation, callback) { ... }`.
- I used the `path.posix.normalize` to convert the backward slashes to forward slashes. I replaced the `new RegExp(file).test(path.normalize(i))` with `/\.css/.test(path.normalize(i))` to prevent it from adding "js" files in a link tag. Also, I added the "defer" to load the js after the document is parsed.
- I added `declare module 'ejs-webpack-plugin';` in index.d.ts to resolve the import warning.

## Screenshots
- issue-1
![issue-1](https://github.com/superNever/ejs-webpack-plugin/assets/120240061/8f3d79e4-3c79-4ebd-a3ae-66dfbac11d27)
- issue-2
![issue-2](https://github.com/superNever/ejs-webpack-plugin/assets/120240061/ce1d12ce-e74a-4bcc-829a-837c24d275dd)
- issue-3
![issue-3](https://github.com/superNever/ejs-webpack-plugin/assets/120240061/322f3e8c-02ff-4b17-8e3c-383e1bc39633)

## Request
Your plugin is just awesome. I had the issue with ejs combining with webpack for months and at last, your plugin has solved the issue. Please look into the PR and let me know if it's worth merging. And I would request you to update the npm distribution as it may help other developers. Thank you 😄.